### PR TITLE
Fix TypeError: Arguments to path.join must be strings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,8 +50,7 @@ gulp.task('build', ['clean', 'sass', 'webpack', 'copy', 'bust'], function () {
 
 gulp.task('sass', function () {
   var filterCSS = filter('**/*.css');
-  return gulp.src(paths.sass)
-    .pipe(sass())
+  return sass(paths.sass)
     .on('error', notifyError)
     .pipe(filterCSS)
     .pipe(autoprefixer())


### PR DESCRIPTION
Doing gulp build resulted in an error described at the following link:
http://stackoverflow.com/questions/28140012/gulp-typeerror-arguments-to-path-join-must-be-strings