### PR TITLE
Don't let BROWSER env variable clobber globals in Webpack builds.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+delete process.env.BROWSER;
 
 // Register babel to have ES6 support on the server
 require("babel/register");


### PR DESCRIPTION
Fixes #32. Cheers to @iam4x.