### PR TITLE
NoErrorsPlugin is not needed with hot/only-dev-server

### DIFF
--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -38,7 +38,6 @@ export default {
 
     // hot reload
     new webpack.HotModuleReplacementPlugin(),
-    new webpack.NoErrorsPlugin(),
 
     // print a webpack progress
     new webpack.ProgressPlugin((percentage, message) => {


### PR DESCRIPTION
This is something silly I've been doing and recommending for a long time. Sorry! There's no need for `NoErrorsPlugin` if you use `hot/only-dev-server`. Hot updates won't blow your app away if you make a syntax error, but at least you'll see the error in the DevTools console! And the subsequent hot updates will just work when you fix that error.

Please verify that this is indeed the case for you. (I don't know, it certainly works this way for my projects, but then maybe Webpack changed the behavior in some version? Just make sure it really works as I describe above.)