### PR TITLE
i18n Portuguese configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This app uses [fluxible-router](https://github.com/yahoo/fluxible-router) for ro
 
 ### Stores
 
-Instead of directly listening to stores, components use fluxible's `@connectToStores` decorator: a store state is passed to components as prop. See for example the [PhotoPage](src/pages/PhotoPage.js) or the [FeaturedPage](src/pages/FeaturedPage.js). 
+Instead of directly listening to stores, components use fluxible's `@connectToStores` decorator: a store state is passed to components as prop. See for example the [PhotoPage](src/pages/PhotoPage.js) or the [FeaturedPage](src/pages/FeaturedPage.js).
 
 `connectToStore` can also "consume" store data without actually listening to any store. This is the case of [NavBar](src/components/NavBar.js) or [LocaleSwitcher](src/components/LocaleSwitcher.js).
 
@@ -146,7 +146,7 @@ This store listens to route actions and set its content according to the current
 
 ## Internationalization (i18n)
 
-To give an example on how to implement i18n in a React application, isomorphic500 supports English and [Italian](https://www.youtube.com/watch?v=9JhuOicPFZY).
+To give an example on how to implement i18n in a React application, isomorphic500 supports English, [Italian](https://www.youtube.com/watch?v=9JhuOicPFZY) and Portuguese.
 
 This app adopts [React Intl](http://formatjs.io/react/), which is a solid library for this purpose.
 
@@ -188,7 +188,7 @@ While this is not required by the 500px API, we can send the current locale to t
 
 ## Development
 
-Run the development version with 
+Run the development version with
 
 ```
 npm run dev
@@ -254,5 +254,3 @@ debug.enable('isomorphic500')
 debug.disable()
 // then, refresh!
 ```
-
-

--- a/config/dev.js
+++ b/config/dev.js
@@ -8,6 +8,6 @@ export default {
   consumerKey: "CLmpqnpwGLKetORtjc5gb9tC2hllfd6cqdfzHqFD",
 
   // Supported locales
-  locales: ["en", "it"]
+  locales: ["en", "it", "pt"]
 
 }

--- a/config/prod.js
+++ b/config/prod.js
@@ -11,6 +11,6 @@ export default {
   trackingId: "UA-46857126-2",
 
   // Supported locales
-  locales: ["en", "it"]
+  locales: ["en", "it", "pt"]
 
 }

--- a/src/intl/pt.js
+++ b/src/intl/pt.js
@@ -1,0 +1,42 @@
+// jscs:disable disallowQuotedKeysInObjects
+export default {
+  locales: ["pt"],
+
+  messages: {
+
+    "meta": {
+      "title": "isomorphic500",
+      "description": "Aplicação de exemplo criada com React e Fluxible",
+      "loadingTitle": "Carregando…",
+      "errorTitle": "Erro ao exibir esta página",
+      "notFoundTitle": "Página não encontrada"
+    },
+
+    "features": {
+      "popular": "Mais Populares",
+      "highest_rated": "Mais Votadas",
+      "upcoming": "Novidades",
+      "editors": "Escolha dos Editores",
+      "fresh_today": "Hoje",
+      "fresh_yesterday": "Ontem",
+      "fresh_week": "Esta Semana"
+    },
+
+    "featured": {
+      "documentTitle": "{feature} em 500px"
+    },
+
+    "home": {
+      "welcome": "Bem vindo ao isomorphic500. Vamos explorar algumas fotos..."
+    },
+
+    "photo": {
+
+      "documentTitle": "{name} – de {user}",
+      "documentDescription": "{name} é uma foto de {user} publicada no 500px",
+
+      "attribution": "Foto de {userLink}",
+      "rating": "Nota {rating}"
+    }
+  }
+};

--- a/src/utils/IntlUtils.js
+++ b/src/utils/IntlUtils.js
@@ -90,6 +90,32 @@ const IntlUtils = {
 
         break;
 
+        // portugues
+        case "pt":
+
+          if (!hasIntl) {
+
+            require.ensure([
+                "intl/locale-data/jsonp/pt",
+                "react-intl/dist/locale-data/pt"
+              ], (require) => {
+
+                require("intl/locale-data/jsonp/pt");
+                debug("Intl locale-data for %s has been downloaded", locale);
+                resolve();
+              }, "locale-pt");
+            }
+            else {
+              require.ensure([
+                  "react-intl/dist/locale-data/pt"
+                ], (require) => {
+                require("react-intl/dist/locale-data/pt");
+                debug("ReactIntl locale-data for %s has been downloaded", locale);
+                resolve();
+              }, "locale-pt-no-intl");
+            }
+        break;
+
         // english
         default:
           if (!hasIntl) {


### PR DESCRIPTION
Add a Portuguese language option.
I've just used `Italian code` part from `switch case` and changed `it` to `pt`.
Just worked.