### PR TITLE
ngrok and deploy do DO with azk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 public
 src/server/webpack-stats.json
+.azk/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ public
 src/server/webpack-stats.json
 .azk/
 *.log
+log/

--- a/Azkfile.js
+++ b/Azkfile.js
@@ -140,7 +140,7 @@ systems({
     // just call with azk shell deploy
     scalable: {"default": 0, "limit": 0},
     envs: {
-      GIT_CHECKOUT_COMMIT_BRANCH_TAG: 'azkfile-deploy',
+      GIT_CHECKOUT_COMMIT_BRANCH_TAG: 'azkfile',
       AZK_RESTART_COMMAND: 'azk restart isomorphic500-prod -Rvv',
       RUN_SETUP: 'true',
       RUN_CONFIGURE: 'true',
@@ -150,7 +150,7 @@ systems({
   "fast-deploy": {
     extends: 'deploy',
     envs: {
-      GIT_CHECKOUT_COMMIT_BRANCH_TAG: 'azkfile-deploy',
+      GIT_CHECKOUT_COMMIT_BRANCH_TAG: 'azkfile',
       AZK_RESTART_COMMAND: 'azk restart isomorphic500-prod -Rvv',
       RUN_SETUP: 'false',
       RUN_CONFIGURE: 'false',

--- a/Azkfile.js
+++ b/Azkfile.js
@@ -80,7 +80,7 @@ systems({
     scalable: { default: 0, limit: 1 },
 
     // do not expect application response
-    wait: false,
+    wait: undefined,
     http: {
       domains: ["#{system.name}.#{azk.default_domain}"]
     },
@@ -106,7 +106,7 @@ systems({
     scalable: { default: 0, limit: 1 },
 
     // do not expect application response
-    wait: false,
+    wait: undefined,
     http: {
       domains: ["#{system.name}.#{azk.default_domain}"]
     },
@@ -117,6 +117,44 @@ systems({
       NGROK_CONFIG: "/ngrok/ngrok.yml",
       NGROK_LOG: "/ngrok/log/ngrok.log"
     }
-  }
+  },
+
+  /////////////////////////////////
+  /// deploy
+  /// -----------------------------
+  /// https://github.com/azukiapp/docker-deploy-digitalocean
+  /////////////////////////////////
+  deploy: {
+    image: {"docker": "azukiapp/deploy-digitalocean"},
+    mounts: {
+                          // your files on remote machine
+                          // will be on /home/git folder
+      "/azk/deploy/src":  path("."),
+                          // will use your public key on server
+                          // that way you can connect with:
+                          // $ ssh root@REMOTE.IP
+      "/azk/deploy/.ssh": path("#{process.env.HOME}/.ssh")
+    },
+    // this is not a server
+    // just call with azk shell deploy
+    scalable: {"default": 0, "limit": 0},
+    envs: {
+      GIT_CHECKOUT_COMMIT_BRANCH_TAG: 'azkfile-deploy',
+      AZK_RESTART_COMMAND: 'azk restart isomorphic500-prod -Rvv',
+      RUN_SETUP: 'true',
+      RUN_CONFIGURE: 'true',
+      RUN_DEPLOY: 'true',
+    }
+  },
+  "fast-deploy": {
+    extends: 'deploy',
+    envs: {
+      GIT_CHECKOUT_COMMIT_BRANCH_TAG: 'azkfile-deploy',
+      AZK_RESTART_COMMAND: 'azk restart isomorphic500-prod -Rvv',
+      RUN_SETUP: 'false',
+      RUN_CONFIGURE: 'false',
+      RUN_DEPLOY: 'true',
+    }
+  },
 
 });

--- a/Azkfile.js
+++ b/Azkfile.js
@@ -4,7 +4,7 @@
 
 // Adds the systems that shape your system
 systems({
-  "isomorphic500-dev": {
+  "isomorphic500": {
     // Dependent systems
     depends: [],
 
@@ -46,7 +46,7 @@ systems({
   },
 
   "isomorphic500-prod": {
-    extends: "isomorphic500-dev",
+    extends: "isomorphic500",
     provision: [
       "npm install"
     ],
@@ -67,9 +67,9 @@ systems({
     }
   },
 
-  "ngrok-dev": {
+  "ngrok": {
     // Dependent systems
-    depends: ["isomorphic500-dev"],
+    depends: ["isomorphic500"],
     image: {docker: "azukiapp/ngrok"},
 
     // Mounts folders to assigned paths

--- a/Azkfile.js
+++ b/Azkfile.js
@@ -132,7 +132,8 @@ systems({
       "/azk/deploy/src":  path("."),
                           // will use your public key on server
                           // that way you can connect with:
-                          // $ ssh root@REMOTE.IP
+                          // $ ssh git@REMOTE.IP
+                          // $ bash
       "/azk/deploy/.ssh": path("#{process.env.HOME}/.ssh")
     },
     // this is not a server

--- a/Azkfile.js
+++ b/Azkfile.js
@@ -1,0 +1,64 @@
+/* global systems sync persistent */
+
+// Documentation: http://docs.azk.io/Azkfile.js
+
+// Adds the systems that shape your system
+systems({
+  isomorphic500: {
+    // Dependent systems
+    depends: [],
+
+    // More images:  http://images.azk.io
+    image: {docker: "azukiapp/node:0.12"},
+
+    // Steps to execute before running instances
+    // use reprovision to run again: `azk restart -R`
+    provision: [
+      "npm install"
+    ],
+    workdir: "/azk/#{manifest.dir}",
+    shell: "/bin/bash",
+    command: "npm run dev",
+
+    // wait for port inside container
+    wait: {retry: 20, timeout: 1000},
+    mounts: {
+      "/azk/#{manifest.dir}": sync("."),
+      "/azk/#{manifest.dir}/node_modules": persistent("#{manifest.dir}/node_modules")
+    },
+    scalable: {default: 1},
+    http: {
+      domains: ["#{system.name}.#{azk.default_domain}"]
+    },
+    ports: {
+      http: "3000/tcp",
+      hot: "3001:3001/tcp"
+    },
+    envs: {
+      HOST_NAME: "#{system.name}.#{azk.default_domain}",
+      NODE_ENV: "dev",
+      PORT: "3000",
+      HOST: "0.0.0.0"
+    }
+  },
+
+  "isomorphic500-prod": {
+    extends: "isomorphic500",
+    provision: [
+      "npm install"
+    ],
+    scalable: {default: 1},
+    command: "npm run build && npm run prod",
+    wait: {retry: 40, timeout: 1000},
+    ports: {
+      http: "8080/tcp"
+    },
+    envs: {
+      HOST_NAME: "#{system.name}.#{azk.default_domain}",
+      NODE_ENV: "production",
+      PORT: "8080",
+      HOST: "0.0.0.0"
+    }
+  }
+
+});

--- a/Azkfile.md
+++ b/Azkfile.md
@@ -1,0 +1,176 @@
+# isomorphic500 :: Azkfile.js
+
+With [azk](http://azk.io/), you don't even need Node.js installed on your machine. It can start the application in both development and production modes. It also configures a [ngrok](https://ngrok.com/) system which allows us to expose the site over the web and analyzes all requests made.
+
+### Systems
+
+#### [isomorphic500](http://isomorphic500.dev.azk.io)
+
+- development version
+- webpack dev hot loader active
+
+#### [isomorphic500-prod](http://isomorphic500-prod.dev.azk.io)
+
+- production version
+
+#### [ngrok](http://ngrok.dev.azk.io)
+
+- exposes dev version
+
+#### [ngrok-prod](http://ngrok-prod.dev.azk.io)
+
+- exposes production version
+
+#### deploy
+
+- automatic deploys to Digital Ocean
+
+#### fast-deploy
+
+- just update code
+
+--------------------
+
+## Running with azk
+
+### Installing azk
+
+- [Install azk on Linux](http://docs.azk.io/en/installation/linux.html)
+- [Install azk on Mac OS X](http://docs.azk.io/en/installation/mac_os_x.html)
+
+- Or simply run:
+> You'll need Docker installed if you are using Linux or VirtualBox if you are using Mac OS X
+
+```bash
+$ curl -Ls http://azk.io/install.sh | bash
+```
+
+### Running isomorphic500 locally
+
+```bash
+$ azk start -Rv isomorphic500
+```
+
+- [isomorphic500.dev.azk.io](http://isomorphic500.dev.azk.io/)
+
+> If you want to run the production environment, just replace `isomorphic500` by `isomorphic500-prod` in the command above.
+
+### Exposing your app to the web
+
+You can expose your app to the web via a public URL using ngrok:
+
+```bash
+$ azk start -Rv ngrok
+```
+
+- [ngrok.dev.azk.io ](http://ngrok.dev.azk.io/)
+
+> If you want to expose the app running in production environment, just replace `ngrok` by `ngrok-prod` in the command above.
+
+
+### Checking logs
+
+```bash
+$ azk logs --follow
+```
+
+### Deploying to Digital Ocean
+
+```sh
+# first you have commit your changes;
+# there will git-hook on remote machine
+
+# call this at first time
+azk shell deploy
+
+# this command is faster, because does not
+# setup/configure the remote machine
+azk shell fast-deploy
+```
+
+--------------------
+
+### Other azk commands
+
+#### stop all containers
+
+```sh
+$ azk stop
+```
+
+#### restart all container
+
+```sh
+$ azk restart
+```
+
+#### restart and reprovision all container
+
+```sh
+$ azk restart -Rvv
+```
+
+#### check logs
+
+```sh
+$ azk logs
+```
+
+#### info on containers
+
+```sh
+$ azk info
+```
+
+--------------------
+
+### azk troubleshooting
+
+*Removing root ownership from files*
+
+Once Docker runs as [root user](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group) inside container, if you want to access `node_modules` files from your machine, you have to set the proper files ownership.
+
+```bash
+# Fix node_modules ownership
+$ sudo chown -R `id -un`:`id -gn` node_modules
+```
+
+*Further help*
+
+See [official azk troubleshooting](http://docs.azk.io/en/troubleshooting/README.html)
+
+-----------------------
+### more on azk
+
+- Official Site
+  http://azk.io
+- Github
+  https://github.com/azukiapp/azk
+- Documentation
+  http://docs.azk.io
+- Images directory created by the azk team
+  http://images.azk.io
+
+### Contribute to azk
+
+- Star azk on Github
+  https://github.com/azukiapp/azk
+- Report an issue
+  https://github.com/azukiapp/azk/issues/new
+- Help solving a reported issue
+  https://github.com/azukiapp/azk/issues
+- Check out our awesome sponsors
+  http://azk.io/#sponsors
+
+### Stay in touch with the azk team
+
+- Sign up the weekly digest
+  http://www.azk.io/#newsletter
+- Follow the blog
+  https://medium.com/azuki-news
+- Talk to our support (chat)
+  https://gitter.im/azukiapp/azk (English) e https://gitter.im/azukiapp/azk/pt (Português)
+- Facebook
+  https://www.facebook.com/azukiapp
+- Twitter
+  http://twitter.com/azukiapp

--- a/README.md
+++ b/README.md
@@ -45,31 +45,16 @@ npm run prod    # then, run the production version
 
 - then open [localhost:8080](http://localhost:8080).
 
-**Start the app with azk + Docker (Linux or MacOSX only)**
+**Start the app with [azk](http://azk.io/) + [Docker](https://www.docker.com/)**
 
-Install azk and docker
-
-```bash
-wget -qO- https://get.docker.com/ | sh   # install Docker
-curl -Ls http://azk.io/install.sh | bash # install azk
-```
-
-**run azk container, dev and prod at same time**
+With [azk](http://azk.io/), you don't even need Node.js installed on your machine. It can start the application in both development and production modes. It also configures a [ngrok](https://ngrok.com/) system which allows us to expose the site over the web and analyzes all requests made.
 
 ```bash
-azk restart -R -v && azk logs --follow
+$ azk agent start
+$ azk start
 ```
 
-- dev:  [isomorphic500.dev.azk.io](http://isomorphic500.dev.azk.io/)
-- prod: [isomorphic500-prod.dev.azk.io](http://isomorphic500-prod.dev.azk.io/)
-
-Removing root ownership from files
-
-```bash
-sudo chown `whoami` -R .
-npm install
-npm run dev
-```
+see [Running with azk](#running-with-azk) for to get more info
 
 
 ## Table of Contents
@@ -94,6 +79,7 @@ npm run dev
   * [.editorconfig](#editorconfig)
   * [Linting](#linting)
   * [Debugging](#debugging)
+* [Running with azk](#running-with-azk)
 
 ## Application structure
 
@@ -281,4 +267,70 @@ From the **browser**, you can enable/disable them by sending this command in the
 debug.enable('isomorphic500')
 debug.disable()
 // then, refresh!
+```
+
+### Running with azk
+
+- [Install azk on Linux](http://docs.azk.io/en/installation/linux.html)
+- [Install azk on Mac OS X](http://docs.azk.io/en/installation/mac_os_x.html)
+
+- Or just run this:
+> You'll need Docker installed if you are using Linux or VirtualBox if you are using Mac OS X
+
+```bash
+$ curl -Ls http://azk.io/install.sh | bash
+```
+
+Run app in both dev and prod environment (one container for each environment):
+
+*local dev*
+
+```bash
+$ azk restart isomorphic500-dev -R -v
+```
+
+- [isomorphic500-dev.dev.azk.io](http://isomorphic500-dev.dev.azk.io/)
+
+*local prod*
+
+```bash
+$ azk restart isomorphic500-prod -R -v
+```
+
+- [isomorphic500-prod.dev.azk.io](http://isomorphic500-prod.dev.azk.io/)
+
+*ngrok dev (will open the ngrok local dashboard with the exposed url)*
+
+```bash
+$ azk restart ngrok-dev -R -v
+```
+
+- [ngrok-dev.dev.azk.io ](http://ngrok-dev.dev.azk.io/)
+
+*ngrok prod (will open the ngrok local dashboard with the exposed url)*
+
+```bash
+$ azk restart ngrok-prod -R -v
+```
+
+- [ngrok-prod.dev.azk.io ](http://ngrok-prod.dev.azk.io/)
+
+__server logs__
+```bash
+$ azk logs --follow
+```
+
+
+Images used:
+
+- [nodejs](http://images.azk.io/#/node)
+- [ngrok](http://images.azk.io/#/ngrok)
+
+Removing root ownership from files:
+
+Once Docker runs as [root user](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group) inside container, if you want to access `node_modules` files from your machine, you have to set the proper files ownership.
+
+```bash
+# Fix node_modules ownership
+$ sudo chown -R `id -un`:`id -gn` node_modules
 ```

--- a/README.md
+++ b/README.md
@@ -43,7 +43,34 @@ npm run build   # First, build for production
 npm run prod    # then, run the production version
 ```
 
-then open [localhost:8080](http://localhost:8080).
+- then open [localhost:8080](http://localhost:8080).
+
+**Start the app with azk + Docker (Linux or MacOSX only)**
+
+Install azk and docker
+
+```bash
+wget -qO- https://get.docker.com/ | sh   # install Docker
+curl -Ls http://azk.io/install.sh | bash # install azk
+```
+
+**run azk container, dev and prod at same time**
+
+```bash
+azk restart -R -v && azk logs --follow
+```
+
+- dev:  [isomorphic500.dev.azk.io](http://isomorphic500.dev.azk.io/)
+- prod: [isomorphic500-prod.dev.azk.io](http://isomorphic500-prod.dev.azk.io/)
+
+Removing root ownership from files
+
+```bash
+sudo chown `whoami` -R .
+npm install
+npm run dev
+```
+
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ see [Running with azk](#running-with-azk) for to get more info
   * [Linting](#linting)
   * [Debugging](#debugging)
 * [Running with azk](#running-with-azk)
-  * [Install azk](#install-azk)
-  * [Azk local run](#azk-local-run)
-  * [Azk ngrok expose](#azk-ngrok-expose)
-  * [Azk troubleshooting](#azk-troubleshooting)
+  * [Installing azk](#installing-azk)
+  * [Running isomorphic500 locally](#running-isomorphic500-locally)
+  * [Exposing your app to the web](#exposing-your-app-to-the-web)
+  * [Checking logs](#checking-logs)
+  * [azk troubleshooting](#azk-troubleshooting)
 
 ## Application structure
 
@@ -302,7 +303,7 @@ $ azk start -Rv isomorphic500
 You can expose your app to the web via a public URL using ngrok:
 
 ```bash
-$ azk start -RV ngrok
+$ azk start -Rv ngrok
 ```
 
 - [ngrok.dev.azk.io ](http://ngrok.dev.azk.io/)

--- a/README.md
+++ b/README.md
@@ -45,17 +45,13 @@ npm run prod    # then, run the production version
 
 - then open [localhost:8080](http://localhost:8080).
 
-**Start the app with [azk](http://azk.io/) + [Docker](https://www.docker.com/)**
-
-With [azk](http://azk.io/), you don't even need Node.js installed on your machine. It can start the application in both development and production modes. It also configures a [ngrok](https://ngrok.com/) system which allows us to expose the site over the web and analyzes all requests made.
+**using [azk](http://azk.io/)**
 
 ```bash
-$ azk agent start
 $ azk start
 ```
 
-see [Running with azk](#running-with-azk) for to get more info
-
+see [Azkfile.md](./Azkfile.md) to get more info
 
 ## Table of Contents
 
@@ -79,12 +75,6 @@ see [Running with azk](#running-with-azk) for to get more info
   * [.editorconfig](#editorconfig)
   * [Linting](#linting)
   * [Debugging](#debugging)
-* [Running with azk](#running-with-azk)
-  * [Installing azk](#installing-azk)
-  * [Running isomorphic500 locally](#running-isomorphic500-locally)
-  * [Exposing your app to the web](#exposing-your-app-to-the-web)
-  * [Checking logs](#checking-logs)
-  * [azk troubleshooting](#azk-troubleshooting)
 
 ## Application structure
 
@@ -274,60 +264,3 @@ debug.disable()
 // then, refresh!
 ```
 
-## Running with azk
-
-### Installing azk
-
-- [Install azk on Linux](http://docs.azk.io/en/installation/linux.html)
-- [Install azk on Mac OS X](http://docs.azk.io/en/installation/mac_os_x.html)
-
-- Or simply run:
-> You'll need Docker installed if you are using Linux or VirtualBox if you are using Mac OS X
-
-```bash
-$ curl -Ls http://azk.io/install.sh | bash
-```
-
-### Running isomorphic500 locally
-
-```bash
-$ azk start -Rv isomorphic500
-```
-
-- [isomorphic500.dev.azk.io](http://isomorphic500.dev.azk.io/)
-
-> If you want to run the production environment, just replace `isomorphic500` by `isomorphic500-prod` in the command above.
-
-### Exposing your app to the web
-
-You can expose your app to the web via a public URL using ngrok:
-
-```bash
-$ azk start -Rv ngrok
-```
-
-- [ngrok.dev.azk.io ](http://ngrok.dev.azk.io/)
-
-> If you want to expose the app running in production environment, just replace `ngrok` by `ngrok-prod` in the command above.
-
-
-### Checking logs
-
-```bash
-$ azk logs --follow
-```
-
-### azk troubleshooting
-
-*Removing root ownership from files*
-
-Once Docker runs as [root user](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group) inside container, if you want to access `node_modules` files from your machine, you have to set the proper files ownership.
-
-```bash
-# Fix node_modules ownership
-$ sudo chown -R `id -un`:`id -gn` node_modules
-```
-
-*Further help*
-
-See [official azk troubleshooting](http://docs.azk.io/en/troubleshooting/README.html)

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ see [Running with azk](#running-with-azk) for to get more info
   * [Linting](#linting)
   * [Debugging](#debugging)
 * [Running with azk](#running-with-azk)
+  * [Install azk](#install-azk)
+  * [Azk local run](#azk-local-run)
+  * [Azk ngrok expose](#azk-ngrok-expose)
+  * [Azk troubleshooting](#azk-troubleshooting)
 
 ## Application structure
 
@@ -269,7 +273,9 @@ debug.disable()
 // then, refresh!
 ```
 
-### Running with azk
+## Running with azk
+
+### Install azk
 
 - [Install azk on Linux](http://docs.azk.io/en/installation/linux.html)
 - [Install azk on Mac OS X](http://docs.azk.io/en/installation/mac_os_x.html)
@@ -280,6 +286,8 @@ debug.disable()
 ```bash
 $ curl -Ls http://azk.io/install.sh | bash
 ```
+
+### Azk local run
 
 Run app in both dev and prod environment (one container for each environment):
 
@@ -298,6 +306,8 @@ $ azk restart isomorphic500-prod -R -v
 ```
 
 - [isomorphic500-prod.dev.azk.io](http://isomorphic500-prod.dev.azk.io/)
+
+### Azk ngrok expose
 
 *ngrok dev (will open the ngrok local dashboard with the exposed url)*
 
@@ -320,13 +330,9 @@ __server logs__
 $ azk logs --follow
 ```
 
+### Azk troubleshooting
 
-Images used:
-
-- [nodejs](http://images.azk.io/#/node)
-- [ngrok](http://images.azk.io/#/ngrok)
-
-Removing root ownership from files:
+*Removing root ownership from files*
 
 Once Docker runs as [root user](https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group) inside container, if you want to access `node_modules` files from your machine, you have to set the proper files ownership.
 
@@ -334,3 +340,7 @@ Once Docker runs as [root user](https://docs.docker.com/installation/ubuntulinux
 # Fix node_modules ownership
 $ sudo chown -R `id -un`:`id -gn` node_modules
 ```
+
+*Further help*
+
+see [official azk troubleshooting](http://docs.azk.io/en/troubleshooting/README.html)

--- a/README.md
+++ b/README.md
@@ -275,62 +275,48 @@ debug.disable()
 
 ## Running with azk
 
-### Install azk
+### Installing azk
 
 - [Install azk on Linux](http://docs.azk.io/en/installation/linux.html)
 - [Install azk on Mac OS X](http://docs.azk.io/en/installation/mac_os_x.html)
 
-- Or just run this:
+- Or simply run:
 > You'll need Docker installed if you are using Linux or VirtualBox if you are using Mac OS X
 
 ```bash
 $ curl -Ls http://azk.io/install.sh | bash
 ```
 
-### Azk local run
-
-Run app in both dev and prod environment (one container for each environment):
-
-*local dev*
+### Running isomorphic500 locally
 
 ```bash
-$ azk restart isomorphic500-dev -R -v
+$ azk start -Rv isomorphic500
 ```
 
-- [isomorphic500-dev.dev.azk.io](http://isomorphic500-dev.dev.azk.io/)
+- [isomorphic500.dev.azk.io](http://isomorphic500.dev.azk.io/)
 
-*local prod*
+> If you want to run the production environment, just replace `isomorphic500` by `isomorphic500-prod` in the command above.
+
+### Exposing your app to the web
+
+You can expose your app to the web via a public URL using ngrok:
 
 ```bash
-$ azk restart isomorphic500-prod -R -v
+$ azk start -RV ngrok
 ```
 
-- [isomorphic500-prod.dev.azk.io](http://isomorphic500-prod.dev.azk.io/)
+- [ngrok.dev.azk.io ](http://ngrok.dev.azk.io/)
 
-### Azk ngrok expose
+> If you want to expose the app running in production environment, just replace `ngrok` by `ngrok-prod` in the command above.
 
-*ngrok dev (will open the ngrok local dashboard with the exposed url)*
 
-```bash
-$ azk restart ngrok-dev -R -v
-```
+### Checking logs
 
-- [ngrok-dev.dev.azk.io ](http://ngrok-dev.dev.azk.io/)
-
-*ngrok prod (will open the ngrok local dashboard with the exposed url)*
-
-```bash
-$ azk restart ngrok-prod -R -v
-```
-
-- [ngrok-prod.dev.azk.io ](http://ngrok-prod.dev.azk.io/)
-
-__server logs__
 ```bash
 $ azk logs --follow
 ```
 
-### Azk troubleshooting
+### azk troubleshooting
 
 *Removing root ownership from files*
 
@@ -343,4 +329,4 @@ $ sudo chown -R `id -un`:`id -gn` node_modules
 
 *Further help*
 
-see [official azk troubleshooting](http://docs.azk.io/en/troubleshooting/README.html)
+See [official azk troubleshooting](http://docs.azk.io/en/troubleshooting/README.html)

--- a/config/dev.js
+++ b/config/dev.js
@@ -10,4 +10,4 @@ export default {
   // Supported locales
   locales: ["en", "it", "pt", "fr"]
 
-}
+};

--- a/config/prod.js
+++ b/config/prod.js
@@ -13,4 +13,4 @@ export default {
   // Supported locales
   locales: ["en", "it", "pt", "fr"]
 
-}
+};

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { FormattedMessage }  from "../utils/IntlComponents";
+import { FormattedMessage } from "../utils/IntlComponents";
 
 class HomePage extends Component {
 

--- a/src/server/intl-polyfill.js
+++ b/src/server/intl-polyfill.js
@@ -1,4 +1,4 @@
-/* global Intl */
+/* global Intl IntlPolyfill */
 
 // Add support for intl on node.js
 // See: http://formatjs.io/guides/runtime-environments/#server

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -8,13 +8,13 @@ var notifyStats = require("./utils/notify-stats");
 
 var assetsPath = path.resolve(__dirname, "../public/assets");
 
-var WEBPACK_HOST = "localhost";
+var WEBPACK_HOST = process.env.HOST_NAME || "0.0.0.0";
 var WEBPACK_PORT = parseInt(process.env.PORT) + 1 || 3001;
 
 module.exports = {
   devtool: "cheap-module-eval-source-map",
   entry: {
-    "main": [
+    main: [
       "webpack-dev-server/client?http://" + WEBPACK_HOST + ":" + WEBPACK_PORT,
       "webpack/hot/only-dev-server",
       "./src/client.js"
@@ -51,10 +51,11 @@ module.exports = {
     }),
 
     // stats
-    function () {
+    function() {
       this.plugin("done", notifyStats);
     },
-    function () {
+
+    function() {
       this.plugin("done", writeStats);
     },
 

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -11,7 +11,7 @@ var assetsPath = path.join(__dirname, "../public/assets");
 module.exports = {
   devtool: "source-map",
   entry: {
-    "main": "./src/client.js"
+    main: "./src/client.js"
   },
   output: {
     path: assetsPath,

--- a/webpack/server.js
+++ b/webpack/server.js
@@ -6,7 +6,7 @@ import config from "./dev.config";
 
 const debug = require("debug")("isomorphic500");
 
-const WEBPACK_HOST = process.env.HOST || "localhost";
+const WEBPACK_HOST = process.env.HOST || "0.0.0.0";
 const WEBPACK_PORT = parseInt(process.env.PORT) + 1 || 3001;
 
 const serverOptions = {


### PR DESCRIPTION
This PR is intended to make it easy to one run the project on his machine.
Using [azk](http://azk.io/), the project is run in a separated context (in containers), so you don't even need Node.js installed on your machine. It can start the application in both development and production modes.

Using containers, we can add other stuff, like databases, elastic search, workers, and be sure that they will work on others' machine.

- https://github.com/azukiapp/azk
- http://images.azk.io

#### README.md (changed)

Minimal description on README and a link that points to [https://github.com/saitodisse/isomorphic500/blob/azkfile-ngrok/Azkfile.md](https://github.com/saitodisse/isomorphic500/blob/azkfile-ngrok/Azkfile.md)
