### PR TITLE
Use externalized message for "Page not found"

### DIFF
--- a/src/pages/NotFoundPage.js
+++ b/src/pages/NotFoundPage.js
@@ -1,9 +1,14 @@
 import React from "react";
+import FormattedMessage from "../utils/FormattedMessage";
 
 class NotFoundPage extends React.Component {
 
   render() {
-    return <h1>Page not found</h1>;
+    return (
+      <div>
+        <FormattedMessage message="meta.notFoundTitle" />
+      </div>
+    );
   }
 
 }


### PR DESCRIPTION
"Page not found" was hardcoded in the JSX fragment for the NotFoundPage component.