### PR TITLE
[Code Review] Pull config values into a store.

### DIFF
--- a/config/dev.js
+++ b/config/dev.js
@@ -8,6 +8,8 @@ export default {
   consumerKey: "CLmpqnpwGLKetORtjc5gb9tC2hllfd6cqdfzHqFD",
 
   // Supported locales
-  locales: ["en", "it", "pt", "fr"]
+  locales: ["en", "it", "pt", "fr"],
+
+  siteName: "isomorphic500 (DEV)"
 
 };

--- a/config/prod.js
+++ b/config/prod.js
@@ -11,6 +11,8 @@ export default {
   trackingId: "UA-46857126-2",
 
   // Supported locales
-  locales: ["en", "it", "pt", "fr"]
+  locales: ["en", "it", "pt", "fr"],
+
+  siteName: "isomorphic500"
 
 };

--- a/src/stores/HtmlHeadStore.js
+++ b/src/stores/HtmlHeadStore.js
@@ -2,7 +2,8 @@ import { BaseStore } from "fluxible/addons";
 import Actions from "../constants/Actions";
 import IntlMessageFormat from "intl-messageformat";
 
-const SITE_NAME = "Isomorphic500";
+import { siteName } from "../config";
+
 const BASE_URL = "http://isomorphic500.herokuapp.com";
 
 /*
@@ -23,7 +24,7 @@ export default class HtmlHeadStore extends BaseStore {
 
   constructor(dispatcher) {
     super(dispatcher);
-    this.siteName = SITE_NAME;
+    this.siteName = siteName;
     this.currentUrl = null;
     this.setInitialState();
   }


### PR DESCRIPTION
The stores have the site name hard coded. If I put this into the dev/prod js config files, they fail to run correctly within a browser, but fine on the server.  The client cannot find '/config/dev.js'...

Why does this method of pulling in the config work in the Html component but not within a store?

**This pull request is not intended to be merged.**